### PR TITLE
fix(esm): add .js suffix to local imports for Node compatibility

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -2,10 +2,10 @@
  * Main converter module - orchestrates the PTH to ONNX conversion.
  */
 
-import { parsePth } from "./pth-parser";
-import { buildOnnxModel } from "./onnx-builder";
-import { serializeOnnx } from "./onnx-serializer";
-import type { ParsedCheckpoint } from "./types";
+import { parsePth } from "./pth-parser.js";
+import { buildOnnxModel } from "./onnx-builder.js";
+import { serializeOnnx } from "./onnx-serializer.js";
+import type { ParsedCheckpoint } from "./types.js";
 
 /**
  * Options for the conversion process.

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,11 @@
  * checkpoint files (.pth) to ONNX format entirely in the browser.
  */
 
-export { pthToOnnx, type ConversionOptions, type ConversionResult, type PthInput } from "./converter";
-export { parsePth, type PthCheckpoint } from "./pth-parser";
-export { buildOnnxModel } from "./onnx-builder";
-export { serializeOnnx } from "./onnx-serializer";
-export { Unpickler, PythonObject, type TorchStorage, type DType } from "./pickle";
+export { pthToOnnx, type ConversionOptions, type ConversionResult, type PthInput } from "./converter.js";
+export { parsePth, type PthCheckpoint } from "./pth-parser.js";
+export { buildOnnxModel } from "./onnx-builder.js";
+export { serializeOnnx } from "./onnx-serializer.js";
+export { Unpickler, PythonObject, type TorchStorage, type DType } from "./pickle.js";
 export type { 
   TensorData, 
   RvcConfig, 
@@ -17,5 +17,5 @@ export type {
   OnnxModel,
   OnnxGraph,
   OnnxNode
-} from "./types";
-export { OnnxDataType } from "./types";
+} from "./types.js";
+export { OnnxDataType } from "./types.js";

--- a/src/onnx-builder.ts
+++ b/src/onnx-builder.ts
@@ -14,8 +14,8 @@ import type {
   OnnxDataType,
   OnnxAttribute,
   TensorData,
-} from "./types";
-import { buildSynthesizerGraph } from "./synthesizer-builder";
+} from "./types.js";
+import { buildSynthesizerGraph } from "./synthesizer-builder.js";
 
 export interface BuildOptions {
   opsetVersion: number;

--- a/src/onnx-serializer.ts
+++ b/src/onnx-serializer.ts
@@ -20,7 +20,7 @@ import {
   OnnxAttribute,
   OnnxDataType,
   TensorData,
-} from "./types";
+} from "./types.js";
 
 /**
  * Serialize an ONNX model to binary protobuf format.

--- a/src/pth-parser.ts
+++ b/src/pth-parser.ts
@@ -15,8 +15,8 @@ import {
   ParsedCheckpoint,
   RvcConfig,
   TensorData,
-} from "./types";
-import { Unpickler, TorchStorage } from "./pickle";
+} from "./types.js";
+import { Unpickler, TorchStorage } from "./pickle.js";
 
 /**
  * Represents the raw structure of a PyTorch checkpoint.

--- a/src/synthesizer-builder.ts
+++ b/src/synthesizer-builder.ts
@@ -20,7 +20,7 @@ import {
   OnnxInitializer,
   OnnxDataType,
   TensorData,
-} from "./types";
+} from "./types.js";
 import {
   resetNameCounter,
   uniqueName,
@@ -58,7 +58,7 @@ import {
   where,
   flip,
   shape,
-} from "./onnx-builder";
+} from "./onnx-builder.js";
 
 // =============================================================================
 // Helper Functions


### PR DESCRIPTION
Awesome project! However, in Node, importing rvc-onnx-web fails because the ESM imports are missing .js extensions. It works fine in web bundlers like Vite or Webpack.
<img width="2389" height="1144" alt="屏幕截图 2026-03-11 215543" src="https://github.com/user-attachments/assets/f219cd75-388d-498e-b329-20cf09ca4c8c" />
This PR fixes the issue by adding .js extensions to local imports.
